### PR TITLE
最新動画を「アップロード済みの動画」リストに変更することで、自動で最新動画が表示されるようにした

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
       <div class="right-content">
         <h2 class="icon">最新動画</h2>
         <div class="frame-wrapper__video">
-          <iframe width="560" height="315" src="https://www.youtube.com/embed/qVAP556eL7U" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/?list=UUo7TRj3cS-f_1D9ZDmuTsjw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# 背景
トップページの最新動画欄で、動画が更新されるたびにvideoIdを変更するのは大変そうだと感じたので。

# やったこと
iframeタグのsrc属性で指定しているURIのvideoId部分を「アップロード済みの動画」再生リストのidに変更することで、自動で最新動画が表示されるようにしました。