### PR TITLE
headerをレスポンシブデザインにした

### DIFF
--- a/about.html
+++ b/about.html
@@ -24,23 +24,24 @@
 
   <body id="about">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="index.html">
-          <img src="img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="profile.html">Profile</a></li>
-          <li><a href="archive.html">Stream Archive</a></li>
-          <li><a href="songs.html">Songs</a></li>
-          <li><a href="information.html">Information</a></li>
-          <li><a href="about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2>このサイトについて</h2>

--- a/about_en.html
+++ b/about_en.html
@@ -24,23 +24,24 @@
 
   <body id="about">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="index.html">
-          <img src="img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="profile.html">Profile</a></li>
-          <li><a href="archive.html">Stream Archive</a></li>
-          <li><a href="songs.html">Songs</a></li>
-          <li><a href="information.html">Information</a></li>
-          <li><a href="about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2>About this site</h2>

--- a/archive.html
+++ b/archive.html
@@ -14,6 +14,7 @@
     />
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.4/css/all.css" />
+    <link rel="stylesheet" href="css/archive.css" />
     <link rel="icon" href="img/favicon.ico" id="favicon" />
     <!-- <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png"> -->
     <script src="JS/thumbnail_select.js" type="text/javascript"></script>
@@ -49,12 +50,14 @@
         <div id="page_top"><a href="wrap"></a></div>
         <h2>過去配信アーカイブ</h2>
         <p>過去配信アーカイブを掲載しています。</p>
-        <ul>
-          <li>
+        <ul class="ul-lead">
+          <li class="ul-lead-item">
             サイトの仕様上、全ての配信は載せきれていません。活動休止復帰後以降の配信がメインとなっています。
           </li>
-          <li>絞り込みを行いたい場合は、ページ右の配信ジャンルから選択してください。</li>
-          <li>
+          <li class="ul-lead-item">
+            絞り込みを行いたい場合は、ページ右の配信ジャンルから選択してください。
+          </li>
+          <li class="ul-lead-item">
             町田ちま公式チャンネル（<a
               href="https://www.youtube.com/channel/UCo7TRj3cS-f_1D9ZDmuTsjw"
               >町田ちま【にじさんじ】</a

--- a/archive.html
+++ b/archive.html
@@ -26,23 +26,24 @@
 
   <body id="archive">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="index.html">
-          <img src="img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="profile.html">Profile</a></li>
-          <li><a href="archive.html">Stream Archive</a></li>
-          <li><a href="songs.html">Songs</a></li>
-          <li><a href="information.html">Information</a></li>
-          <li><a href="about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <div id="page_top"><a href="wrap"></a></div>

--- a/common.html
+++ b/common.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
     <title>サンプルページ</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
@@ -29,23 +30,24 @@
 
   <body id="ここにページのid（最新情報の場合は記事のジャンルごとにclassで管理）">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="index.html">
-          <img src="img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="profile.html">Profile</a></li>
-          <li><a href="archive.html">Stream Archive</a></li>
-          <li><a href="songs.html">Songs</a></li>
-          <li><a href="information.html">Information</a></li>
-          <li><a href="about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content"></div>
     </div>

--- a/contact.html
+++ b/contact.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
     <title>Contact - 町田ちま 非公式ファンサイト「inocesias.」</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
@@ -13,6 +14,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="css/contact.css" />
     <link rel="icon" href="img/favicon.ico" id="favicon" />
     <!-- <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png"> -->
     <script src="JS/jquery-3.6.0.min.js"></script>
@@ -21,23 +23,24 @@
 
   <body id="contact">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="index.html">
-          <img src="img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="profile.html">Profile</a></li>
-          <li><a href="archive.html">Stream Archive</a></li>
-          <li><a href="songs.html">Songs</a></li>
-          <li><a href="information.html">Information</a></li>
-          <li><a href="about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2>問い合わせフォーム</h2>

--- a/css/archive.css
+++ b/css/archive.css
@@ -1,0 +1,9 @@
+@charset "UTF-8";
+
+.ul-lead {
+  margin-bottom: 1.875rem;
+}
+
+.ul-lead-item {
+  font-size: 15px;
+}

--- a/css/contact.css
+++ b/css/contact.css
@@ -1,0 +1,5 @@
+@charset "UTF-8";
+
+header {
+  background-image: url(../img/bg2.png);
+}

--- a/css/style.css
+++ b/css/style.css
@@ -69,7 +69,15 @@ a:hover {
 header {
   background-image: url(../img/bg.webp);
   background-repeat: no-repeat;
-  background-size: cover;
+
+  @media screen and (max-width: 600px) {
+    background-size: cover;
+  }
+
+  @media screen and (min-width: 601px) {
+    background-size: 100%;
+    background-attachment: fixed;
+  }
 }
 
 header .inner {

--- a/css/style.css
+++ b/css/style.css
@@ -38,7 +38,7 @@ a:hover {
 
 .inner {
   @media screen and (width <= 600px) {
-    padding: 3rem 1.5rem;
+    padding: 48px 24px;
   }
 
   @media screen and (600px < width) {
@@ -76,7 +76,7 @@ header {
   @media screen and (600px < width) {
     background-size: 100%;
     background-attachment: fixed;
-    padding-block: 65px;
+    padding-block: 74px;
   }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -542,15 +542,6 @@ option {
   width: 60%;
 }
 
-#information {
-  background-image: url(../img/bg.webp);
-  background-repeat: no-repeat;
-  background-position: center top;
-  background-attachment: fixed;
-  background-size: 100% auto;
-  font-family: "Noto Serif JP", serif;
-}
-
 #information #wrap .content .container {
   display: grid;
   grid-template-columns: 300px 300px 300px;

--- a/css/style.css
+++ b/css/style.css
@@ -274,14 +274,6 @@ p {
   border-left: 9px solid #edddbb;
 }
 
-#profile {
-  background-image: url(../img/bg.webp);
-  background-repeat: no-repeat;
-  background-position: center top;
-  background-attachment: fixed;
-  background-size: 100% auto;
-}
-
 #profile h3 {
   font-family: "Noto Serif JP", serif;
   font-weight: 350;

--- a/css/style.css
+++ b/css/style.css
@@ -2,11 +2,9 @@
 
 body {
   margin: 0;
-  padding: 0;
-  background-color: #ffffff;
+  font-family: "Noto Serif JP", serif;
   font-size: 18px;
   line-height: 2;
-  min-width: 980px;
 }
 
 p,
@@ -18,7 +16,6 @@ h5,
 h6,
 li {
   margin-top: 0;
-  font-family: "Noto Serif JP", serif;
 }
 
 img {
@@ -37,6 +34,18 @@ a {
 
 a:hover {
   text-decoration: underline;
+}
+
+.inner {
+  @media screen and (max-width: 600px) {
+    padding: 3rem 1.5rem;
+  }
+
+  @media screen and (min-width: 601px) {
+    width: 960px;
+    height: 180px;
+    margin: auto;
+  }
 }
 
 #loading {
@@ -58,26 +67,59 @@ a:hover {
 }
 
 header {
-  width: 960px;
-  height: 100px;
-  margin: 0 auto;
+  background-image: url(../img/bg.webp);
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+header .inner {
+  display: flex;
+  align-items: center;
+
+  @media screen and (max-width: 600px) {
+    flex-direction: column;
+    justify-content: center;
+    gap: 1rem;
+  }
+
+  @media screen and (min-width: 601px) {
+    justify-content: space-between;
+  }
 }
 
 .logo {
-  float: left;
-  margin-top: 60px;
-  margin-left: 10px;
+  @media screen and (min-width: 601px) {
+    margin-top: -17px; /* flexへの変更前とpx単位で合わせるために設定 */
+    margin-left: 10px;
+  }
+}
+
+.logo-img {
+  @media screen and (max-width: 600px) {
+    width: 37.8vw;
+  }
 }
 
 .global_nav {
-  float: right;
-  margin-top: 57px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+
+  @media screen and (max-width: 600px) {
+    font-size: 20px;
+    row-gap: 0.5rem;
+    column-gap: 1rem;
+  }
+
+  @media screen and (min-width: 601px) {
+    margin-right: 18px;
+    margin-top: -17px; /* flexへの変更前とpx単位で合わせるために設定 */
+    font-size: 24px;
+    gap: 2rem;
+  }
 }
 
 .global_nav li {
-  float: left;
-  margin: 0 18px;
-  font-size: 24px;
   list-style: none;
 }
 
@@ -96,7 +138,6 @@ header {
 #wrap {
   clear: both;
   background-color: #ffffff;
-  margin-top: 80px;
 }
 
 .content {
@@ -120,14 +161,6 @@ input[type="email"]:focus,
 textarea:focus {
   border: 2px solid #ffbdc1;
   outline: 0;
-}
-
-#index {
-  background-image: url(../img/bg.webp);
-  background-repeat: no-repeat;
-  background-position: center top;
-  background-attachment: fixed;
-  background-size: 100% auto;
 }
 
 h2 {
@@ -311,10 +344,11 @@ p {
 }
 
 #archive p,
-li {
+#archive li {
   font-weight: 150;
   font-size: 15px;
 }
+
 #archive ul {
   margin-bottom: 30px;
 }
@@ -902,18 +936,9 @@ option {
     display: none;
   }
 }
+
 @media screen and (max-width: 600px) {
   /* 画面サイズが600px以下の場合に適用 */
-  body {
-    font-size: 28px;
-    -webkit-text-size-adjust: 100%;
-  }
-
-  p {
-    font-size: 28px;
-    padding: 15px 0;
-  }
-
   h2 {
     font-family: "Noto Serif JP", serif;
     font-weight: 150;
@@ -921,33 +946,6 @@ option {
     padding-top: 50px;
     margin-bottom: 20px;
     border-bottom: 1px solid #b5a98f;
-  }
-
-  header {
-    width: auto;
-    margin: 0 5%;
-  }
-
-  .logo {
-    float: none;
-    text-align: center;
-  }
-
-  .logo img {
-    width: 370px;
-  }
-
-  .global_nav {
-    float: none;
-    margin-top: 50px;
-    text-align: center;
-  }
-
-  .global_nav li {
-    display: inline;
-    margin: 0 18px;
-    font-size: 40px;
-    float: none;
   }
 
   footer {
@@ -1208,9 +1206,10 @@ option {
   }
 
   #archive .content p,
-  li {
+  #archive .content li {
     font-size: 28px;
   }
+
   #archive h3 {
     font-size: 30px;
   }

--- a/css/style.css
+++ b/css/style.css
@@ -738,14 +738,6 @@ option {
   margin: 20px 10px;
 }
 
-#about {
-  background-image: url(../img/bg.webp);
-  background-repeat: no-repeat;
-  background-position: center top;
-  background-attachment: fixed;
-  background-size: 100% auto;
-}
-
 #about .content {
   padding-bottom: 10px;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -740,15 +740,6 @@ option {
   padding-top: 15px;
 }
 
-#contact {
-  background-image: url(../img/bg2.png);
-  background-repeat: no-repeat;
-  background-position: center top;
-  background-attachment: fixed;
-  background-size: 100% auto;
-  font-family: "Noto Serif JP", serif;
-}
-
 #contact .content {
   padding-bottom: 3px;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -794,15 +794,6 @@ option {
   margin-left: 300px;
 }
 
-#success {
-  background-image: url(../img/bg.webp);
-  background-repeat: no-repeat;
-  background-position: center top;
-  background-attachment: fixed;
-  background-size: 100% auto;
-  font-family: "Noto Serif JP", serif;
-}
-
 #success h2 {
   font-weight: 150;
   padding-top: 50px;

--- a/css/style.css
+++ b/css/style.css
@@ -42,7 +42,7 @@ a:hover {
   }
 
   @media screen and (min-width: 601px) {
-    width: 960px;
+    width: min(960px, 100%);
     height: 180px;
     margin: auto;
   }
@@ -75,11 +75,11 @@ header {
 header .inner {
   display: flex;
   align-items: center;
+  gap: 1rem;
 
   @media screen and (max-width: 600px) {
     flex-direction: column;
     justify-content: center;
-    gap: 1rem;
   }
 
   @media screen and (min-width: 601px) {
@@ -115,7 +115,7 @@ header .inner {
     margin-right: 18px;
     margin-top: -17px; /* flexへの変更前とpx単位で合わせるために設定 */
     font-size: 24px;
-    gap: 2rem;
+    column-gap: 2rem;
   }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -481,14 +481,6 @@ option {
   cursor: pointer;
   background-image: url(../img/yt_icon_rgb.png);
 }
-#songs {
-  background-image: url(../img/bg.webp);
-  background-repeat: no-repeat;
-  background-position: center top;
-  background-attachment: fixed;
-  background-size: 100% auto;
-  font-family: "Noto Serif JP", serif;
-}
 
 #songs h3 {
   clear: both;

--- a/css/style.css
+++ b/css/style.css
@@ -24,7 +24,7 @@ img {
 
 ul {
   margin: 0;
-  padding: 0;
+  padding-left: 1.5rem;
 }
 
 a {
@@ -101,6 +101,7 @@ header .inner {
 }
 
 .global_nav {
+  padding: 0;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -332,20 +333,6 @@ p {
   font-weight: 130;
   font-size: 14px;
   padding: 5px 0;
-}
-
-#archive p,
-#archive li {
-  font-weight: 150;
-  font-size: 15px;
-}
-
-#archive ul {
-  margin-bottom: 30px;
-}
-
-#archive li {
-  margin-left: 20px;
 }
 
 #page_top {

--- a/css/style.css
+++ b/css/style.css
@@ -810,14 +810,6 @@ option {
   width: 300px;
 }
 
-#timeline {
-  background-image: url(../img/bg.webp);
-  background-repeat: no-repeat;
-  background-position: center top;
-  background-attachment: fixed;
-  background-size: 100% auto;
-}
-
 #timeline .timeline-h2 {
   font-size: 27px;
   font-weight: 150;

--- a/css/style.css
+++ b/css/style.css
@@ -37,11 +37,11 @@ a:hover {
 }
 
 .inner {
-  @media screen and (max-width: 600px) {
+  @media screen and (width <= 600px) {
     padding: 3rem 1.5rem;
   }
 
-  @media screen and (min-width: 601px) {
+  @media screen and (600px < width) {
     width: min(960px, 100%);
     height: 180px;
     margin: auto;
@@ -70,11 +70,11 @@ header {
   background-image: url(../img/bg.webp);
   background-repeat: no-repeat;
 
-  @media screen and (max-width: 600px) {
+  @media screen and (width <= 600px) {
     background-size: cover;
   }
 
-  @media screen and (min-width: 601px) {
+  @media screen and (600px < width) {
     background-size: 100%;
     background-attachment: fixed;
   }
@@ -85,25 +85,25 @@ header .inner {
   align-items: center;
   gap: 1rem;
 
-  @media screen and (max-width: 600px) {
+  @media screen and (width <= 600px) {
     flex-direction: column;
     justify-content: center;
   }
 
-  @media screen and (min-width: 601px) {
+  @media screen and (600px < width) {
     justify-content: space-between;
   }
 }
 
 .logo {
-  @media screen and (min-width: 601px) {
+  @media screen and (600px < width) {
     margin-top: -17px; /* flexへの変更前とpx単位で合わせるために設定 */
     margin-left: 10px;
   }
 }
 
 .logo-img {
-  @media screen and (max-width: 600px) {
+  @media screen and (width <= 600px) {
     width: 37.8vw;
   }
 }
@@ -114,13 +114,13 @@ header .inner {
   flex-wrap: wrap;
   justify-content: center;
 
-  @media screen and (max-width: 600px) {
+  @media screen and (width <= 600px) {
     font-size: 20px;
     row-gap: 0.5rem;
     column-gap: 1rem;
   }
 
-  @media screen and (min-width: 601px) {
+  @media screen and (600px < width) {
     margin-right: 18px;
     margin-top: -17px; /* flexへの変更前とpx単位で合わせるために設定 */
     font-size: 24px;

--- a/css/style.css
+++ b/css/style.css
@@ -3,7 +3,6 @@
 body {
   margin: 0;
   font-family: "Noto Serif JP", serif;
-  font-size: 18px;
   line-height: 2;
 }
 
@@ -115,7 +114,7 @@ header .inner {
   justify-content: center;
 
   @media screen and (width <= 600px) {
-    font-size: 20px;
+    font-size: 1.25rem;
     row-gap: 0.5rem;
     column-gap: 1rem;
   }
@@ -123,8 +122,8 @@ header .inner {
   @media screen and (600px < width) {
     margin-right: 18px;
     margin-top: -17px; /* flexへの変更前とpx単位で合わせるために設定 */
-    font-size: 24px;
-    column-gap: 2rem;
+    font-size: 1.5rem;
+    column-gap: 2.25rem;
   }
 }
 
@@ -138,8 +137,8 @@ header .inner {
 }
 
 .global_nav li a:hover {
-  border-bottom: 1.2px solid #000000;
-  padding-bottom: 2.5px;
+  border-bottom: 0.075rem solid #000000;
+  padding-bottom: 0.15625rem;
   text-decoration: none;
   cursor: pointer;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -43,7 +43,6 @@ a:hover {
 
   @media screen and (600px < width) {
     width: min(960px, 100%);
-    height: 180px;
     margin: auto;
   }
 }
@@ -77,6 +76,7 @@ header {
   @media screen and (600px < width) {
     background-size: 100%;
     background-attachment: fixed;
+    padding-block: 65px;
   }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -322,15 +322,6 @@ p {
   margin-bottom: 30px;
 }
 
-#archive {
-  background-image: url(../img/bg.webp);
-  background-repeat: no-repeat;
-  background-position: center top;
-  background-attachment: fixed;
-  background-size: 100% auto;
-  font-family: "Noto Serif JP", serif;
-}
-
 #archive h3 {
   font-weight: 130;
   font-size: 16px;

--- a/css/style.css
+++ b/css/style.css
@@ -634,15 +634,6 @@ option {
   color: #ffffff;
 }
 
-#info_detail {
-  background-image: url(../img/bg.webp);
-  background-repeat: no-repeat;
-  background-position: center top;
-  background-attachment: fixed;
-  background-size: 100% auto;
-  font-family: "Noto Serif JP", serif;
-}
-
 #info_detail h2 {
   margin-bottom: 0;
 }

--- a/index.html
+++ b/index.html
@@ -32,23 +32,24 @@
 
   <body id="index">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="index.html">
-          <img src="img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="profile.html">Profile</a></li>
-          <li><a href="archive.html">Stream Archive</a></li>
-          <li><a href="songs.html">Songs</a></li>
-          <li><a href="information.html">Information</a></li>
-          <li><a href="about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap" class="clearfix">
       <div class="content">
         <div class="main-content">

--- a/info/appearance/000005.html
+++ b/info/appearance/000005.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">ニコニコ生放送「にじさんじのハッピーアワー!!」出演</h2>

--- a/info/appearance/000015.html
+++ b/info/appearance/000015.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">にじさんじ AR STAGE "LIGHT UP TONES" 開催決定！</h2>

--- a/info/appearance/000017.html
+++ b/info/appearance/000017.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">町田ちま 3Dお披露目配信決定！！</h2>

--- a/info/appearance/000018.html
+++ b/info/appearance/000018.html
@@ -25,23 +25,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">Webメディア『Up-Station』のにじさんじリレー企画がスタート予定！</h2>

--- a/info/appearance/000024.html
+++ b/info/appearance/000024.html
@@ -25,23 +25,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">マリカにじさんじ杯に町田ちまが参戦！</h2>

--- a/info/appearance/000027.html
+++ b/info/appearance/000027.html
@@ -25,23 +25,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">新春！にじさんじ麻雀杯2022に町田ちまが参加！</h2>

--- a/info/appearance/000028.html
+++ b/info/appearance/000028.html
@@ -25,23 +25,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">にじさんじユニット歌謡祭に町田ちまが参加！</h2>

--- a/info/appearance/000031.html
+++ b/info/appearance/000031.html
@@ -25,23 +25,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">レヴィ・エリファ3周年記念ライブのゲストとして町田ちまが参加！</h2>

--- a/info/appearance/000034.html
+++ b/info/appearance/000034.html
@@ -25,23 +25,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">にじさんじフェス2022 出演情報</h2>

--- a/info/goods/000002.html
+++ b/info/goods/000002.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">町田ちまオリジナルグッズ第2弾販売開始！</h2>

--- a/info/goods/000004.html
+++ b/info/goods/000004.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">にじFes2021 漫画研究部　ライバー創作本再販開始！</h2>

--- a/info/goods/000022.html
+++ b/info/goods/000022.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">新ビジュアルグッズ第12弾 販売決定！</h2>

--- a/info/goods/000030.html
+++ b/info/goods/000030.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">Welcome Goods&Welcome Voice 販売開始！</h2>

--- a/info/goods/000032.html
+++ b/info/goods/000032.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">にじさんじブルーミングシーズン グッズ販売決定！</h2>

--- a/info/goods/000033.html
+++ b/info/goods/000033.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">にじさんじサマーバレンタイン グッズ販売決定！</h2>

--- a/info/goods/000035.html
+++ b/info/goods/000035.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">町田ちま　LINEスタンプ販売開始！</h2>

--- a/info/goods/000040.html
+++ b/info/goods/000040.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">町田ちま 誕生日グッズ＆ボイス販売開始！</h2>

--- a/info/infocommon.html
+++ b/info/infocommon.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">タイトル</h2>

--- a/info/music/000019.html
+++ b/info/music/000019.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">町田ちま初のオリジナルソング『6月のプレリュード』リリース決定！</h2>

--- a/info/music/000029.html
+++ b/info/music/000029.html
@@ -19,23 +19,24 @@
 
 <body id="info_detail">
   <div id="loading"></div>
-  <!-- header開始 -->
+
   <header>
-    <div class="logo">
-      <a href="../../index.html">
-        <img src="../../img/logo.png" alt="inocesias.">
+    <div class="inner">
+      <a class="logo" href="/index.html">
+        <img class="logo-img" src="/img/logo.png" alt="inocesias." />
       </a>
+      <nav>
+        <ul class="global_nav">
+          <li><a href="/profile.html">Profile</a></li>
+          <li><a href="/archive.html">Stream Archive</a></li>
+          <li><a href="/songs.html">Songs</a></li>
+          <li><a href="/information.html">Information</a></li>
+          <li><a href="/about.html">About</a></li>
+        </ul>
+      </nav>
     </div>
-    <nav>
-      <ul class="global_nav">
-        <li><a href="../../profile.html">Profile</a></li>
-        <li><a href="../../archive.html">Stream Archive</a></li>
-        <li><a href="../../songs.html">Songs</a></li>
-        <li><a href="../../information.html">Information</a></li>
-        <li><a href="../../about.html">About</a></li>
-      </ul>
-    </nav>
   </header>
+
   <div id="wrap">
     <div class="content">
       <h2 class="icon">『フォニイ- ツミキ / 町田ちま(Cover)』が1000万回再生を突破！</h2>

--- a/info/nornis/000036.html
+++ b/info/nornis/000036.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">"Nornis"始動 & "Abyssal Zone"リリース！</h2>

--- a/info/nornis/000037.html
+++ b/info/nornis/000037.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">Nornis 6月メディア掲載情報</h2>

--- a/info/nornis/000038.html
+++ b/info/nornis/000038.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">Nornis 2ndデジタルシングル「Daydreamer」リリース！</h2>

--- a/info/nornis/000039.html
+++ b/info/nornis/000039.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">Nornis 7月, 8月メディア掲載情報（随時更新）</h2>

--- a/info/official/000001.html
+++ b/info/official/000001.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">にじさんじ初のカバーソングアルバム「Prismatic Colors」発売開始！</h2>

--- a/info/official/000003.html
+++ b/info/official/000003.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">3周年PJ"PALETTE"始動！2曲同時リリース決定！！</h2>

--- a/info/official/000010.html
+++ b/info/official/000010.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">にじさんじジューンブライド2021 販売決定！</h2>

--- a/info/official/000020.html
+++ b/info/official/000020.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">町田ちま 誕生日グッズ＆ボイス販売決定！</h2>

--- a/info/official/000021.html
+++ b/info/official/000021.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">第2回にじ歌DAYに町田ちまが参加！</h2>

--- a/info/official/000023.html
+++ b/info/official/000023.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">第55回「ヤシロ＆ササキのレバガチャダイパン」に町田ちまが出演！</h2>

--- a/info/official/000025.html
+++ b/info/official/000025.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">第56回「ヤシロ＆ササキのレバガチャダイパン」に町田ちまが出演！</h2>

--- a/info/official/000026.html
+++ b/info/official/000026.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">3.0 Brushup!! 町田ちまを含む4名に実装決定！</h2>

--- a/info/voice/000006.html
+++ b/info/voice/000006.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="Inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">GWボイス&amp;アウトドアボイス 発売決定！</h2>

--- a/info/voice/000007.html
+++ b/info/voice/000007.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">にじさんじ秋満喫ボイス2020・にじさんじ冬支度ボイス2020の再販が決定！</h2>

--- a/info/voice/000008.html
+++ b/info/voice/000008.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">にじさんじGWボイス2020・にじさんじ試験勉強ボイスの再販が決定！</h2>

--- a/info/voice/000009.html
+++ b/info/voice/000009.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="Inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">にじさんじあめもようボイス 再販決定！</h2>

--- a/info/voice/000011.html
+++ b/info/voice/000011.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="Inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">

--- a/info/voice/000012.html
+++ b/info/voice/000012.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="Inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">あめもようボイス2021&amp;七夕ボイス2021 販売決定！</h2>

--- a/info/voice/000013.html
+++ b/info/voice/000013.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="Inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">にじさんじ夏真っ盛りボイス2020　再販決定！</h2>

--- a/info/voice/000014.html
+++ b/info/voice/000014.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="Inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">ホワイトデーボイス2021・春休みボイス2021の再販が決定！</h2>

--- a/info/voice/000016.html
+++ b/info/voice/000016.html
@@ -24,23 +24,24 @@
 
   <body id="info_detail">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="../../index.html">
-          <img src="../../img/logo.png" alt="Inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="../../profile.html">Profile</a></li>
-          <li><a href="../../archive.html">Stream Archive</a></li>
-          <li><a href="../../songs.html">Songs</a></li>
-          <li><a href="../../information.html">Information</a></li>
-          <li><a href="../../about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2 class="icon">にじさんじ海ボイス2021&amp;にじさんじ夏休みボイス2021　発売決定！</h2>

--- a/information.html
+++ b/information.html
@@ -36,23 +36,24 @@
 
   <body id="information">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="index.html">
-          <img src="img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="profile.html">Profile</a></li>
-          <li><a href="archive.html">Stream Archive</a></li>
-          <li><a href="songs.html">Songs</a></li>
-          <li><a href="information.html">Information</a></li>
-          <li><a href="about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2>インフォメーション</h2>

--- a/profile.html
+++ b/profile.html
@@ -23,23 +23,24 @@
   </head>
   <body id="profile">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="index.html">
-          <img src="img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="profile.html">Profile</a></li>
-          <li><a href="archive.html">Stream Archive</a></li>
-          <li><a href="songs.html">Songs</a></li>
-          <li><a href="information.html">Information</a></li>
-          <li><a href="about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <div id="page_top"><a href="wrap"></a></div>

--- a/profile_en.html
+++ b/profile_en.html
@@ -23,23 +23,24 @@
   </head>
   <body id="profile">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="index.html">
-          <img src="img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="profile.html">Profile</a></li>
-          <li><a href="archive.html">Stream Archive</a></li>
-          <li><a href="songs.html">Songs</a></li>
-          <li><a href="information.html">Information</a></li>
-          <li><a href="about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <div id="page_top"><a href="wrap"></a></div>

--- a/songs.html
+++ b/songs.html
@@ -25,23 +25,24 @@
 
   <body id="songs">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="index.html">
-          <img src="img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="profile.html">Profile</a></li>
-          <li><a href="archive.html">Stream Archive</a></li>
-          <li><a href="songs.html">Songs</a></li>
-          <li><a href="information.html">Information</a></li>
-          <li><a href="about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <div id="page_top"><a href="wrap"></a></div>

--- a/success.html
+++ b/success.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
     <title>送信完了</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
@@ -21,23 +22,24 @@
 
   <body id="success">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="index.html">
-          <img src="img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="profile.html">Profile</a></li>
-          <li><a href="archive.html">Stream Archive</a></li>
-          <li><a href="songs.html">Songs</a></li>
-          <li><a href="information.html">Information</a></li>
-          <li><a href="about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <h2>送信完了</h2>

--- a/timeline.html
+++ b/timeline.html
@@ -32,23 +32,24 @@
 
   <body id="timeline">
     <div id="loading"></div>
-    <!-- header開始 -->
+
     <header>
-      <div class="logo">
-        <a href="index.html">
-          <img src="img/logo.png" alt="inocesias." />
+      <div class="inner">
+        <a class="logo" href="/index.html">
+          <img class="logo-img" src="/img/logo.png" alt="inocesias." />
         </a>
+        <nav>
+          <ul class="global_nav">
+            <li><a href="/profile.html">Profile</a></li>
+            <li><a href="/archive.html">Stream Archive</a></li>
+            <li><a href="/songs.html">Songs</a></li>
+            <li><a href="/information.html">Information</a></li>
+            <li><a href="/about.html">About</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav>
-        <ul class="global_nav">
-          <li><a href="profile.html">Profile</a></li>
-          <li><a href="archive.html">Stream Archive</a></li>
-          <li><a href="songs.html">Songs</a></li>
-          <li><a href="information.html">Information</a></li>
-          <li><a href="about.html">About</a></li>
-        </ul>
-      </nav>
     </header>
+
     <div id="wrap">
       <div class="content">
         <div id="page_top"><a href="wrap"></a></div>


### PR DESCRIPTION
## 背景
- コンテンツの横幅を固定しているため、デバイスによってフォントサイズが変わってしまう問題を修正したい（スマホでのフォントサイズがインフレしてたのもこれが原因）
- headerの範囲がなんか変なのを直したかった（画像1, 画像2）

![現在のheader](https://github.com/fuj1kky/machita-chima-fansite-project/assets/64892946/e53e9814-1b3a-48c1-a178-f5a2195178df)
画像1　現在のheader

![今回作成したheader](https://github.com/fuj1kky/machita-chima-fansite-project/assets/64892946/a3321b0b-1d93-4924-b8ab-398b48631051)
画像2　今回作成したheader

## やったこと
- headerをfloatからflexに置き換えた
- 画面サイズが601px以上960px未満のときも破綻しないようにnavを折り返し可能にした
- アクセシビリティの観点から、フォントサイズ周りをpxからremに変えた